### PR TITLE
chore: use dependencyDashboard for all repos by default

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
     "config:base",
     "schedule:weekly"
   ],
+  "dependencyDashboard": true,
   "rangeStrategy": "update-lockfile",
   "automerge": true,
   "major": {


### PR DESCRIPTION
## Changes:

- Turn on Renovate Dashboard for all repos that are "onboarded" and use Renovate bot

## Context: 

I noticed that the `netlify` org uses the Renovate dashboard in a lot of repos (at least 3 that I checked).
So maybe it would be easier/cleaner to turn on the dashboard by default in this config.
That way you don't have to turn on the dashboard in separate repository configs.

After you've merged this PR, you can remove the `masterIssue` (old name) or `dependencyDashboard` property (if it's set to `true`) from the Renovate config file in any downstream repos that extend from this config.

But maybe you want to use the dashboard on specific repos only and not on others.
In that case, just close the PR, and leave things as they are now.