### PR TITLE
make a go/default.json

### DIFF
--- a/go/default.json
+++ b/go/default.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["config:base"],
+  "postUpdateOptions": ["gomodTidy"],
+  "docker": {
+    "enabled": false
+  },
+  "docker-compose": {
+    "enabled": false
+  },
+  "labels": ["type: chore"],
+  "prBodyNotes": ["{{#if isMajor}}:warning: MAJOR MAJOR MAJOR :warning:{{/if}}"]
+}
+


### PR DESCRIPTION
This way other repos can reference this config (and we can grow it). They should be able to use the `extends["github>netlify/renovate-config//go/default"]`