### PR TITLE
chore: group only Netlify Build packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,10 +15,13 @@
   },
   "packageRules": [
     {
-      "packagePatterns": ["^@netlify", "^netlify"],
-      "groupName": "netlify packages",
+      "matchPackagePatterns": ["^@netlify", "^netlify"],
       "rangeStrategy": "bump",
       "schedule": null
+    },
+    {
+      "matchSourceUrlPrefixes": ["https://github.com/netlify/build"],
+      "groupName": "Netlify Build packages"
     },
     {
       "matchPackageNames": ["husky"],


### PR DESCRIPTION
Please note that renovate applies all matching rules (doesn't stop at the first matching one)