### PR TITLE
feat: Set semanticCommitType to fix

### DIFF
--- a/rust-default.json
+++ b/rust-default.json
@@ -5,6 +5,7 @@
   "timezone": "Europe/Paris",
   "schedule": "after 4am and before 9am every weekday",
   "lockfileMaintenance": true,
+  "semanticCommitType": "fix",
   "packageRules": [
     {
       "packageNames": ["capnp", "capnpc"],


### PR DESCRIPTION
'chore' commits don't count as 'user-facing' for release-please, which
means we have to push dummy commits just to poke release-please after we
update dependencies.

Using `fix(deps)`, we 1) still see it's for deps, 2) poke release-please
as soon as we merge renovate PRs.

Discussed with @mraerino ahead of time.