### PR TITLE
fix: add `escape-string-regexp`

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,6 +24,10 @@
       "groupName": "Netlify Build packages"
     },
     {
+      "matchPackageNames": ["escape-string-regexp"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["husky"],
       "allowedVersions": "<5"
     }


### PR DESCRIPTION
Background in https://github.com/netlify/netlify-headers-parser/pull/34

`escape-string-regexp@v5` requires Node 12 and ES modules.