### PR TITLE
fix: add `filter-obj`

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,6 +28,10 @@
       "allowedVersions": "<5"
     },
     {
+      "matchPackageNames": ["filter-obj"],
+      "allowedVersions": "<3"
+    },
+    {
       "matchPackageNames": ["husky"],
       "allowedVersions": "<5"
     }


### PR DESCRIPTION
`filter-obj@3` requires ES modules and Node 12.