### PR TITLE
chore: ignore packages versions that require Node.js >= 12

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,6 +34,22 @@
     {
       "matchPackageNames": ["husky"],
       "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["ora"],
+      "allowedVersions": "<6"
+    },
+    {
+      "matchPackageNames": ["locate-path"],
+      "allowedVersions": "<7"
+    },
+    {
+      "matchPackageNames": ["find-up"],
+      "allowedVersions": "<6"
+    },
+    {
+      "matchPackageNames": ["env-paths"],
+      "allowedVersions": "<3"
     }
   ]
 }


### PR DESCRIPTION
Related to https://github.com/netlify/team-dev/issues/30

Last round of packages updates from the CLI repo