### PR TITLE
chore: ignore packages versions that require Node.js >= 12

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,6 +50,14 @@
     {
       "matchPackageNames": ["env-paths"],
       "allowedVersions": "<3"
+    },
+    {
+      "matchPackageNames": ["path-exists"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["junk"],
+      "allowedVersions": "<4"
     }
   ]
 }


### PR DESCRIPTION
See https://github.com/netlify/zip-it-and-ship-it/pull/598 and https://github.com/netlify/zip-it-and-ship-it/pull/611