### PR TITLE
fix: add `node-fetch` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,6 +44,10 @@
       "allowedVersions": "<7"
     },
     {
+      "matchPackageNames": ["node-fetch"],
+      "allowedVersions": "<3"
+    },
+    {
       "matchPackageNames": ["find-up"],
       "allowedVersions": "<6"
     },


### PR DESCRIPTION
`node-fetch@3` requires ES modules + Node 12.20.0