### PR TITLE
fix: add `is-docker` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,6 +36,10 @@
       "allowedVersions": "<5"
     },
     {
+      "matchPackageNames": ["is-docker"],
+      "allowedVersions": "<3"
+    },
+    {
       "matchPackageNames": ["ora"],
       "allowedVersions": "<6"
     },


### PR DESCRIPTION
`is-docker@3` requires ES modules and Node 12.20.0