### PR TITLE
chore: add `p-locate@v6` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -64,6 +64,10 @@
       "allowedVersions": "<5"
     },
     {
+      "matchPackageNames": ["p-locate"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["junk"],
       "allowedVersions": "<4"
     }


### PR DESCRIPTION
`p-locate@v6` requires Node 12 and ES modules.