### PR TITLE
fix: add `get-port` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,6 +32,10 @@
       "allowedVersions": "<3"
     },
     {
+      "matchPackageNames": ["get-port"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["husky"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
`get-port@v6` requires ES modules and Node 12.