### PR TITLE
fix: add exception for `boxen`

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,6 +24,10 @@
       "groupName": "Netlify Build packages"
     },
     {
+      "matchPackageNames": ["boxen"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["escape-string-regexp"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
`boxen@v6` requires ES modules and Node 12.