### PR TITLE
fix: add exception for `map-obj@v5`

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,10 @@
       "allowedVersions": "<7"
     },
     {
+      "matchPackageNames": ["map-obj"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["node-fetch"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
`map-obj@v5` requires Node 12 and ES modules.