### PR TITLE
fix: add `@npmcli/map-workspaces` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,6 +24,10 @@
       "groupName": "Netlify Build packages"
     },
     {
+      "matchPackageNames": ["@npmcli/map-workspaces"],
+      "allowedVersions": "<2"
+    },
+    {
       "matchPackageNames": ["boxen"],
       "allowedVersions": "<6"
     },


### PR DESCRIPTION
`@npmcli/map-workspaces` v2 requires Node 12 and ES modules.