### PR TITLE
chore: Group rustls packages

### DIFF
--- a/rust-default.json
+++ b/rust-default.json
@@ -41,7 +41,7 @@
       "groupName": "tracing packages"
     },
     {
-      "packagePatterns": ["hyper-rustls", "rustls", "rustls-native-certs", "tokio-rustls"],
+      "matchPackageNames": ["hyper-rustls", "rustls", "rustls-native-certs", "tokio-rustls"],
       "groupName": "rustls packages"
     }
   ],


### PR DESCRIPTION
Those belong together and are updated mostly in lockstep.