### PR TITLE
chore: change renovate to rebase only on conflicts

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackagePatterns": ["^@netlify", "^netlify", "^github.com/netlify"],


### PR DESCRIPTION
When a repo requires a branch to be up to date before merging, renovate rebases PRs on each change to the default branch.
Since we already use Kodiak to keep branches up to date, and it does it more efficiently (just before merging the PR, and not on each change to the default branch), this PR configures renovate to only rebase when a PR is conflicted.

See https://docs.renovatebot.com/configuration-options/#rebasewhen