### PR TITLE
chore: add exception for `pino`

### DIFF
--- a/default.json
+++ b/default.json
@@ -81,6 +81,10 @@
       "allowedVersions": "<5"
     },
     {
+      "matchPackageNames": ["pino"],
+      "allowedVersions": "<7"
+    },
+    {
       "matchPackageNames": ["p-locate"],
       "allowedVersions": "<6"
     },


### PR DESCRIPTION
`pino@7` does not support Node 10.