### PR TITLE
chore: group zisi with build dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,7 +21,8 @@
     },
     {
       "matchSourceUrlPrefixes": ["https://github.com/netlify/build"],
-      "groupName": "Netlify Build packages"
+      "matchPackageNames": ["@netlify/zip-it-and-ship-it"],
+      "groupName": "Netlify packages"
     },
     {
       "matchPackageNames": ["husky"],


### PR DESCRIPTION
Since `zip-it-and-ship-it` is a dependency of `netlify/build` it makes sense to group those to avoid different versions of `zip-it-and-ship-it` being used in Netlify CLI