### PR TITLE
chore: add rule for `p-event@5`

### DIFF
--- a/default.json
+++ b/default.json
@@ -86,6 +86,10 @@
       "allowedVersions": "<7"
     },
     {
+      "matchPackageNames": ["p-event"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["p-locate"],
       "allowedVersions": "<6"
     },


### PR DESCRIPTION
`p-event@v5` does not support Node 10 and requires native ES modules, so we cannot upgrade yet.