### PR TITLE
chore: add rule for `process-exists`

### DIFF
--- a/default.json
+++ b/default.json
@@ -86,6 +86,10 @@
       "allowedVersions": "<7"
     },
     {
+      "matchPackageNames": ["process-exists"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["p-event"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
This adds a rule for `process-exists@5` because it drops support for Node 10 and requires native ES modules.