### PR TITLE
chore: add rule for `ps-list@8`

### DIFF
--- a/default.json
+++ b/default.json
@@ -100,6 +100,10 @@
     {
       "matchPackageNames": ["pkg-dir"],
       "allowedVersions": "<6"
+    },
+    {
+      "matchPackageNames": ["ps-list"],
+      "allowedVersions": "<8"
     }
   ]
 }


### PR DESCRIPTION
This adds a rule for `ps-list@8` since that version drops support for Node 10 and requires native ES modules.