### PR TITLE
fix: add `execa@v6`

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,10 @@
       "allowedVersions": "<5"
     },
     {
+      "matchPackageNames": ["execa"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["filter-obj"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
Execa v6 requires native ES modules, so we cannot yet upgrade to it.