### PR TITLE
fix: add `sort-on@v5`

### DIFF
--- a/default.json
+++ b/default.json
@@ -108,6 +108,10 @@
     {
       "matchPackageNames": ["ps-list"],
       "allowedVersions": "<8"
+    },
+    {
+      "matchPackageNames": ["sort-on"],
+      "allowedVersions": "<5"
     }
   ]
 }


### PR DESCRIPTION
`sort-on@v5` requires pure ES modules so we cannot use it yet.