### PR TITLE
fix: dangling comma in JSON

### DIFF
--- a/default.json
+++ b/default.json
@@ -212,6 +212,6 @@
     {
       "matchPackageNames": ["yargs"],
       "allowedVersions": "<17"
-    },
+    }
   ]
 }


### PR DESCRIPTION
This fixes a syntax error in `default.json`.