### PR TITLE
fix: add `test-each` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -210,6 +210,10 @@
       "allowedVersions": "<9"
     },
     {
+      "matchPackageNames": ["test-each"],
+      "allowedVersions": "<3"
+    },
+    {
       "matchPackageNames": ["yargs"],
       "allowedVersions": "<17"
     }


### PR DESCRIPTION
This adds an exception for `test-each@v3` since it requires pure ES modules.