### PR TITLE
chore: add rules from `js-client`

### DIFF
--- a/default.json
+++ b/default.json
@@ -186,8 +186,16 @@
       "allowedVersions": "<6"
     },
     {
+      "matchPackageNames": ["p-map"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["p-reduce"],
       "allowedVersions": "<3"
+    },
+    {
+      "matchPackageNames": ["p-wait-for"],
+      "allowedVersions": "<4"
     },
     {
       "matchPackageNames": ["read-pkg"],
@@ -212,6 +220,10 @@
     {
       "matchPackageNames": ["supports-color"],
       "allowedVersions": "<9"
+    },
+    {
+      "matchPackageNames": ["tempy"],
+      "allowedVersions": "<2"
     },
     {
       "matchPackageNames": ["test-each"],


### PR DESCRIPTION
This adds [the rules from the `js-client`](https://github.com/netlify/js-client/blob/main/renovate.json5) so we can simplify the `renovate.json5` in that repository.