### PR TITLE
chore: add `read-pkg` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -190,6 +190,10 @@
       "allowedVersions": "<3"
     },
     {
+      "matchPackageNames": ["read-pkg"],
+      "allowedVersions": "<6"
+    },
+    {
       "matchPackageNames": ["read-pkg-up"],
       "allowedVersions": "<8"
     },


### PR DESCRIPTION
`read-pkg@v6` cannot be upgraded because it requires pure ES modules.