### PR TITLE
fix: re-enable some dependencies related to Node 10 support

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,10 +26,6 @@
       "groupName": "Netlify packages"
     },
     {
-      "matchPackageNames": ["@npmcli/map-workspaces"],
-      "allowedVersions": "<2"
-    },
-    {
       "matchPackageNames": ["@sindresorhus/slugify"],
       "allowedVersions": "<2"
     },
@@ -158,10 +154,6 @@
       "allowedVersions": "<5"
     },
     {
-      "matchPackageNames": ["pino"],
-      "allowedVersions": "<7"
-    },
-    {
       "matchPackageNames": ["pkg-dir"],
       "allowedVersions": "<6"
     },
@@ -228,10 +220,6 @@
     {
       "matchPackageNames": ["test-each"],
       "allowedVersions": "<3"
-    },
-    {
-      "matchPackageNames": ["yargs"],
-      "allowedVersions": "<17"
     }
   ]
 }


### PR DESCRIPTION
Now that we've dropped Node 10 support, some dependencies can be upgraded.

Most of the dependencies still require pure ES modules support unfortunately (see https://github.com/netlify/pod-workflow/issues/321).