### PR TITLE
fix: add `chalk@v5` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,6 +42,10 @@
       "allowedVersions": "<6"
     },
     {
+      "matchPackageNames": ["chalk"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["clean-stack"],
       "allowedVersions": "<4"
     },


### PR DESCRIPTION
`chalk@v5` requires pure ES modules, so we cannot use it yet.