### PR TITLE
fix(node): remove Node.js constraint

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,9 +1,4 @@
 {
-  "force": {
-    "constraints": {
-      "node": "< 15.0.0"
-    }
-  },
   "extends": ["config:base", "schedule:weekly"],
   "rangeStrategy": "update-lockfile",
   "automerge": true,


### PR DESCRIPTION
We added this constraint to force an old version of `npm` to keep old version of lock files (see https://github.com/netlify/renovate-config/pull/4)

I think we can remove it now