### PR TITLE
chore: disable lock file management

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
     "automerge": false
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "rebaseWhen": "conflicted",
   "packageRules": [


### PR DESCRIPTION
Going to disable this until https://github.com/renovatebot/renovate/issues/13014 is resolved, as it creates too much noise (a PR almost every 1-2 hours for every Node.js/JS repo).