### PR TITLE
chore: add `p-timeout` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -229,6 +229,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["p-timeout"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["p-wait-for"],
       "allowedVersions": "<4"
     },


### PR DESCRIPTION
`p-timeout` `v5` requires pure ES modules, so we need to add an exception.