### PR TITLE
chore: add `log-symbols` exception

### DIFF
--- a/default.json
+++ b/default.json
@@ -149,6 +149,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["log-symbols"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["map-obj"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
`log-symbols` `v5` requires pure ES modules, so we need to add an exception.