### PR TITLE
chore: add exceptions for pure ESM dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -174,6 +174,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["node-version-alias"],
+      "allowedVersions": "<2"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["ora"],
       "allowedVersions": "<6"
     },

--- a/default.json
+++ b/default.json
@@ -291,6 +291,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["test-each"],
       "allowedVersions": "<3"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["to-readable-stream"],
+      "allowedVersions": "<3"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -234,6 +234,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["p-timeout"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["p-wait-for"],
       "allowedVersions": "<4"
     },

--- a/default.json
+++ b/default.json
@@ -149,6 +149,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["log-symbols"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["map-obj"],
       "allowedVersions": "<5"
     },

--- a/default.json
+++ b/default.json
@@ -34,6 +34,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["ansi-styles"],
+      "allowedVersions": "<6"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["boxen"],
       "allowedVersions": "<6"
     },

--- a/default.json
+++ b/default.json
@@ -54,6 +54,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["configstore"],
+      "allowedVersions": "<6"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["env-paths"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
This adds more exceptions for packages which require pure ES modules, since we have not completed migration yet.