### PR TITLE
chore: add exception for `dot-prop`

### DIFF
--- a/default.json
+++ b/default.json
@@ -59,6 +59,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["dot-prop"],
+      "allowedVersions": "<7"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["env-paths"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
This adds an exception for `dot-prop@v7` since this version requires pure ES modules.