### PR TITLE
chore: upgrade `is-plain-obj` for ESM migrated repositories

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["ansi-escapes"],
       "allowedVersions": "<5"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["is-plain-obj"],
+      "allowedVersions": "<4"
     }
   ]
 }

--- a/shared.json
+++ b/shared.json
@@ -134,11 +134,6 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["is-plain-obj"],
-      "allowedVersions": "<4"
-    },
-    {
-      "matchManagers": ["npm"],
       "matchPackageNames": ["junk"],
       "allowedVersions": "<4"
     },


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/36

This allows `is-plain-obj` to be upgraded for ESM-migrated repositories.
This is mostly meant to try out the new configuration.