### PR TITLE
chore: add exception for `pretty-bytes`

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -26,6 +26,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["got"],
       "allowedVersions": "<11"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["pretty-bytes"],
+      "allowedVersions": "<6"
     }
   ]
 }


### PR DESCRIPTION
`pretty-bytes@v6` requires Node 14. This PR adds a rule to not upgrade it while we still support Node 12.