### PR TITLE
Upgrade KSG via regex

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -8,6 +8,16 @@
     "enabled": false
   },
   "labels": ["type: chore"],
-  "prBodyNotes": ["{{#if isMajor}}:warning: MAJOR MAJOR MAJOR :warning:{{/if}}"]
+  "prBodyNotes": [
+    "{{#if isMajor}}:warning: MAJOR MAJOR MAJOR :warning:{{/if}}"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^KSGFile(\\.ya?ml)?$"],
+      "matchStrings": ["ksg_version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "KSG",
+      "lookupNameTemplate": "netlify/ksg-cli",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
 }
-


### PR DESCRIPTION
This will make renovate open PRs when a new version of KSG is released.

Example: https://github.com/netlify/cdn-test-runner/pull/34