### PR TITLE
Support different semver variations for KSG

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -14,7 +14,9 @@
   "regexManagers": [
     {
       "fileMatch": ["^KSGFile(\\.ya?ml)?$"],
-      "matchStrings": ["ksg_version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      "matchStrings": [
+        "ksg_version: (?<currentValue>v\\d+(\\.\\d+(\\.\\d+)?)?)"
+      ],
       "depNameTemplate": "KSG",
       "lookupNameTemplate": "netlify/ksg-cli",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
This will also pick up when the current version is set as `v2` or `v2.11`