### PR TITLE
Expand ksg version matching

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -15,7 +15,7 @@
     {
       "fileMatch": ["^KSGFile(\\.ya?ml)?$"],
       "matchStrings": [
-        "ksg_version: (?<currentValue>v\\d+(\\.\\d+(\\.\\d+)?)?)"
+        "ksg_version: \"?(?<currentValue>v\\d+(\\.\\d+(\\.\\d+([-\\.][\\w\\.-]+)?)?)?)\"?"
       ],
       "depNameTemplate": "KSG",
       "lookupNameTemplate": "netlify/ksg-cli",


### PR DESCRIPTION
This is kinda getting out of hand 😅 

Regex101 to understand & verify the regex: https://regex101.com/r/HWWplq/1

This adds two things:
- Detect values that are quoted (yes, technically invalid yaml would be detected, but that should be irrelevant here)
- Allow suffixes after the version

Would i rather just use a yaml parser? Yes!
Do i have the time to teach that to renovate? No.