### PR TITLE
fix: fix config to correctly group netlify packages

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -19,6 +19,10 @@
     {
       "matchManagers": ["npm"],
       "matchSourceUrlPrefixes": ["https://github.com/netlify/build"],
+      "groupName": "Netlify packages"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["@netlify/zip-it-and-ship-it"],
       "groupName": "Netlify packages"
     },


### PR DESCRIPTION
This was [done](https://github.com/netlify/cli/pull/5157) in the CLI already to test this out and it [instantly started working](https://github.com/netlify/cli/pull/5158).

`matchers` in packageRules are combined with AND which makes the netlify grouping not match anything.