### PR TITLE
Avoid creating PRs for digest updates

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -11,6 +11,12 @@
   "prBodyNotes": [
     "{{#if isMajor}}:warning: MAJOR MAJOR MAJOR :warning:{{/if}}"
   ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "digest": { "masterIssueApproval": true }
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^KSGFile(\\.ya?ml)?$"],


### PR DESCRIPTION
We sometimes use Go modules pinned to a specific commit instead of a tag.
Renovate by default then produces an update for every new commit to that repo.
Instead, we'll likely only want to update the dependency manually or when there is a newer tag available.

This change makes it so that these `digest` type updates are only put into an issue and not created as a PR.
My understanding is that we'll still get a PR for when there was a new tag on the dependency.