### PR TITLE
chore: remove locked packages

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -30,16 +30,6 @@
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["inquirer"],
       "groupName": "Inquirer packages"
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["got"],
-      "allowedVersions": "<11"
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["pretty-bytes"],
-      "allowedVersions": "<6"
     }
   ]
 }


### PR DESCRIPTION
These packages were locked because of Node.js 14, so it is finally time to allow updates for them.