### PR TITLE
Include some useful regex manager presets

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "regexManagers:dockerfileVersions",
+    "regexManagers:githubActionsVersions"
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
These can be used to updated versions in places where renovate is not able to detect a dependency. See https://docs.renovatebot.com/presets-regexManagers/