### PR TITLE
chore: disable PR limit

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -10,6 +10,7 @@
   },
   "labels": ["dependencies"],
   "rebaseWhen": "conflicted",
+  "prConcurrentLimit": 0,
   "packageRules": [
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#prconcurrentlimit for docs.

In most of our repos, we always have 10 renovate PRs open, but then the important ones are always rate-limited, and we have to manually invoke their creation in the dashboard.

This PR removes that limit, so PRs are opened as soon as Renovate notices it.

This worked well in Buildbot (see https://github.com/netlify/buildbot/pull/2784), so i'm proposing the addition to our shared Renovate config.