### PR TITLE
Improve Go rules

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -47,6 +47,27 @@
         "cloud.google.com/go/storage"
       ],
       "groupName": "google-sdk"
+    },
+    {
+      "matchManagers": [
+        "gomod",
+        "regex",
+        "docker"
+      ],
+      "packageNames": [
+        "go",
+        "golang"
+      ],
+      "groupName": "Go version"
+    },
+    {
+      "matchManagers": [
+        "circleci"
+      ],
+      "packageNames": [
+        "cimg/go"
+      ],
+      "groupName": "Go version"
     }
   ],
   "regexManagers": [

--- a/go-default.json
+++ b/go-default.json
@@ -7,9 +7,6 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "docker": {
-    "enabled": false
-  },
   "docker-compose": {
     "enabled": false
   },


### PR DESCRIPTION
- Re-enable the Docker manager: We sometimes build Go binaries inside of docker and should keep the Go version up to date. Example: https://github.com/netlify/socketeer/blob/0cff37add5cb85ae365b7875a88ed39ebd1a571c/Dockerfile#L5
- Group Go updates: Opens only a single PR for updating the Go version in multiple places