### PR TITLE
Reduce noise from rebases in Go preset

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -4,6 +4,7 @@
     "regexManagers:dockerfileVersions",
     "regexManagers:githubActionsVersions"
   ],
+  "rebaseWhen": "conflicted",
   "postUpdateOptions": [
     "gomodTidy"
   ],


### PR DESCRIPTION
This will help with notification overload from renovate after every merge.

Since we're mostly using merge queues, we don't care that a PR is up-to-date before we add it to the queue.