### PR TITLE
Group golang.org/x dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/core-pod-adn
+* @netlify/team-runtime

--- a/go-default.json
+++ b/go-default.json
@@ -39,6 +39,12 @@
       "groupName": "aws-sdk"
     },
     {
+      "packagePatterns": [
+        "^golang\\.org/x/"
+      ],
+      "groupName": "golang-x"
+    },
+    {
       "packageNames": [
         "github.com/DataDog/datadog-go/v5",
         "gopkg.in/DataDog/dd-trace-go.v1"


### PR DESCRIPTION
I noticed that the golang.org/x modules generally get updated at the same time (they all get version bumped at the same time, and some of them depend on each other) so I figure it might make sense to just group these in one PR to cut down on the renovate notifications a bit.

<img width="821" height="328" alt="Screenshot 2025-10-10 at 09 51 01" src="https://github.com/user-attachments/assets/2b00af2d-15a5-499f-a5e8-52fa61702a53" />
