### PR TITLE
Add 3-day minimumReleaseAge to shared presets

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -21,6 +21,7 @@
   "prBodyNotes": [
     "{{#if isMajor}}:warning: MAJOR MAJOR MAJOR :warning:{{/if}}"
   ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": [
@@ -32,6 +33,12 @@
       "addLabels": [
         "golang"
       ]
+    },
+    {
+      "matchPackagePatterns": [
+        "^github\\.com/netlify/"
+      ],
+      "minimumReleaseAge": null
     },
     {
       "packagePatterns": [

--- a/shared.json
+++ b/shared.json
@@ -9,6 +9,7 @@
   },
   "labels": ["dependencies"],
   "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
@@ -23,7 +24,8 @@
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@netlify", "^netlify", "^github.com/netlify"],
       "rangeStrategy": "bump",
-      "schedule": null
+      "schedule": null,
+      "minimumReleaseAge": null
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Contributes to https://linear.app/netlify/issue/EX-2222/investigate-time-gated-dependency-updates-for-supply-chain-mitigation

## Summary

Adds `minimumReleaseAge: "3 days"` to the shared Renovate presets so PRs are only opened for dependency versions that have been published for at least 3 days. Internal Netlify packages are exempt.

**Why:** waiting 3 days after a release gives the ecosystem a short window to surface broken or malicious versions (typosquats, compromised maintainers, regressions caught by early adopters) before they land in our repos. Costs us a small delay; saves us from same-day landmines.

**What changed:**
- `shared.json` (inherited by `default.json` and `esm.json`) — top-level `"minimumReleaseAge": "3 days"`, plus `"minimumReleaseAge": null` on the existing internal-`@netlify/*` packageRule to keep our own packages flowing same-day.
- `go-default.json` — top-level `"minimumReleaseAge": "3 days"`, plus a new packageRule waiving the gate for `^github\.com/netlify/`.

## Blast radius

Affects every repo in the netlify org that extends one of these presets — roughly 80 repos based on a code search across the org. A few repos already set their own `minimumReleaseAge` (e.g. `netlify-react-ui`); those values win over the preset and are unaffected.

Surfaced by an audit of pod-experience repos: 16 of 21 had no stability gate at all (relied on these presets, which previously set no minimum age). This propagates a sensible default to all consumers rather than fixing it 16 times.

## Test plan

- [ ] Confirm JSON is valid (already verified locally with `python3 -m json.tool`)
- [ ] Optional: dry-run Renovate against one consumer repo (e.g. `netlify/cli`) to confirm the gate applies and internal packages are still ungated
- [ ] Merge and watch the next round of Renovate PRs across consumer repos — verify external bumps respect the 3-day delay and `@netlify/*` bumps still open immediately

cc @netlify/team-runtime as code owners — flag if you'd rather this not be the org-wide default, or if you'd prefer a different duration than 3 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)